### PR TITLE
Adds md5hashing.net

### DIFF
--- a/index.json
+++ b/index.json
@@ -962,6 +962,7 @@
   "mbe.kr",
   "mbx.cc",
   "mciek.com",
+  "md5hashing.net",
   "mega.zik.dj",
   "meinspamschutz.de",
   "meltmail.com",


### PR DESCRIPTION
This domain provides anon disposable mailboxes [ [link](https://md5hashing.net/anonymous/email) ].

We have seen a number of fake users make use of this service.